### PR TITLE
Feature/send day

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ require("dotenv").config();
 
 const { ImagesService } = require("./services/Services");
 
+const dayjs = require('dayjs')
+
 const { Client, GatewayIntentBits } = require("discord.js");
 const client = new Client({
     intents: [
@@ -31,6 +33,9 @@ client.on('messageCreate', async(msg) => {
             msg.channel.send("Here's your meme!");
             const imgMeme = await imagesService.getMemes();
             msg.channel.send(imgMeme);
+            break;
+        case '!day':
+            msg.reply(`Hello today is ${dayjs().format("DD-MMMM-YYYY")}`);
             break;
         default:
             msg.reply(`Sorry the command "${msg.content}" didn't exist.`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "axios": "^1.6.7",
+        "dayjs": "^1.11.10",
         "discord.js": "^14.14.1",
         "dotenv": "^16.4.1"
       }
@@ -196,6 +197,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "axios": "^1.6.7",
+    "dayjs": "^1.11.10",
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.1"
   }


### PR DESCRIPTION
## Description

Added new !day command that sends the user the day we're on.

### New dependencies

* Day.js Dependencie.

### New features

* Submit the date of the current day.

### Comands 

<table>
    <!--Headlines-->
    <tr>
      <th>Commands</th>
      <th>Description</th>
      <th>Exit Message</th>
    </tr>
    <!--Comand !Hello-->
    <tr>
      <td>!day</td>
      <td>Send the current day</td>
      <td>Hello today is [day_format_of_today]</td>
    </tr>
</table>

## Where should reviewer start?

You can start checking in the index.js file inside the switch and specifically the "!day" case.

## Type of change

Please delete options that are not relevant.

- [x] Feature
- [ ] Fix
- [ ] Test
- [x] Chore
- [ ] Tech debt
- [ ] Docs
- [ ] Style
- [ ] Build
- [ ] Refactor
- [ ] Revert

## Evidence

![image](https://github.com/JosueRenteria/LunaBot-Discord/assets/92546462/9e27a0fb-a1c5-4a2a-9da2-d1b8755483b6)

