### PR TITLE
Refactor/detach channels

### DIFF
--- a/channels/channels.js
+++ b/channels/channels.js
@@ -1,0 +1,10 @@
+module.exports = {
+    general: {
+        token: process.env.CHANNEL1_TOKE,
+        allowedCommands: ["hello", "day"]
+    },
+    memes: {
+        token: process.env.CHANNEL2_TOKE,
+        allowedCommands: ["meme"]
+    }
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 require("dotenv").config();
 
+const channelsConfig = require("./channels/channels");
 const commands = require("./commands/commands");
 
 const { Client, GatewayIntentBits } = require("discord.js");
@@ -22,8 +23,20 @@ client.on('messageCreate', async(msg) => {
     const prefijoComando = '!';
     if (!msg.content.startsWith(prefijoComando)) return;
 
-    const args = msg.content.slice(prefijoComando.length).trim().split(/ +/);
-    const command = args.shift().toLowerCase();
+    const channelConfig = channelsConfig[msg.channel.name];
 
-    commands[command](msg);
+    if (channelConfig) {
+        const allowedCommands = channelConfig.allowedCommands || [];
+
+        const args = msg.content.slice(prefijoComando.length).trim().split(/ +/);
+        const command = args.shift().toLowerCase();
+
+        if (allowedCommands.includes(command)) {
+            if (commands.hasOwnProperty(command)) {
+                commands[command](msg);
+            } else {
+                msg.reply(`Sorry, the command "${command}" is not implemented.`);
+            }
+        }
+    }
 });


### PR DESCRIPTION
## Description

A refactoring was carried out for the handling of the commands, the commands were divided to be able to use them in different channels.

### New features

* Discord Channels with Different Commands.

## Where should reviewer start?

You can start with the channels.js file and move to the index.js file in the client.on

## Type of change

Please delete options that are not relevant.

- [x] Feature
- [ ] Fix
- [ ] Test
- [ ] Chore
- [ ] Tech debt
- [ ] Docs
- [ ] Style
- [ ] Build
- [x] Refactor
- [ ] Revert

## Evidence

![image](https://github.com/JosueRenteria/LunaBot-Discord/assets/92546462/2e6e0255-7843-4869-82c3-9898d9ac0777)

